### PR TITLE
Add end-to-end tests for queryIterator continuation token

### DIFF
--- a/source/lib/queryExecutionContext/defaultQueryExecutionContext.js
+++ b/source/lib/queryExecutionContext/defaultQueryExecutionContext.js
@@ -44,8 +44,8 @@ var DefaultQueryExecutionContext = Base.defineClass(
         this.currentIndex = 0;
         this.currentPartitionIndex = 0;
         this.fetchFunctions = (Array.isArray(fetchFunctions)) ? fetchFunctions : [fetchFunctions];
-        this.continuation = options ? options.continuation : null;
         this.options = options || {};
+        this.continuation = this.options.continuation || null;
         this.state = DefaultQueryExecutionContext.STATES.start;
     },
     {


### PR DESCRIPTION
This PR adds some end-to-end continuation token tests for queryIterator. This would help finalize https://github.com/Azure/azure-documentdb-node/pull/166

@stefan-akelius  @moderakh @mingliu @rnagpal